### PR TITLE
fix repository url of spring-milefotnes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-miletone-local</url>
+			<url>http://repo.spring.io/libs-milestone-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
Build failed because of wrong repository url.

```
[INFO] ------------------------------------------------------------------------
[INFO] Building Config Server 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] >>> spring-boot-maven-plugin:1.1.5.RELEASE:run (default-cli) @ configserver >>>
Downloading: http://repo.spring.io/libs-snapshot-local/org/springframework/security/spring-security-rsa/1.0.0.M2/spring-security-rsa-1.0.0.M2.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.745 s
[INFO] Finished at: 2014-09-11T16:57:02+09:00
[INFO] Final Memory: 11M/118M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project configserver: Could not resolve dependencies for project org.demo:configserver:jar:0.0.1-SNAPSHOT: Failed to collect dependencies at org.springframework.cloud:spring-cloud-config-server:jar:1.0.0.BUILD-SNAPSHOT -> org.springframework.security:spring-security-rsa:jar:1.0.0.M2: Failed to read artifact descriptor for org.springframework.security:spring-security-rsa:jar:1.0.0.M2: Could not transfer artifact org.springframework.security:spring-security-rsa:pom:1.0.0.M2 from/to spring-snapshots (http://repo.spring.io/libs-snapshot-local): Failed to transfer file: http://repo.spring.io/libs-snapshot-local/org/springframework/security/spring-security-rsa/1.0.0.M2/spring-security-rsa-1.0.0.M2.pom. Return code is: 409 , ReasonPhrase:Conflict. -> [Help 1]
```
