### PR TITLE
Updated default branch name for github repos.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ spring:
         git:
           uri: https://github.com/spring-cloud-samples/config-repo
           basedir: target/config
+          default-label: main
 
 ---
 spring:


### PR DESCRIPTION
As part of Github's change to rename 'master' branch to 'main', this change is necessary. Else configserver doesnt works properly.